### PR TITLE
Add simple catalog and contact pages

### DIFF
--- a/app/(default)/catalog/page.tsx
+++ b/app/(default)/catalog/page.tsx
@@ -1,0 +1,42 @@
+export const metadata = {
+  title: "Каталог - АЛМ",
+  description: "Каталог продукции",
+};
+
+import Image from "next/image";
+import Link from "next/link";
+import Product1 from "@/public/images/workflow-01.png";
+import Product2 from "@/public/images/workflow-02.png";
+
+export default function Catalog() {
+  return (
+    <section>
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="py-12 md:py-20">
+          <h1 className="pb-8 text-center font-nacelle text-3xl font-semibold" data-aos="fade-up">
+            Каталог продукции «АЛМ»
+          </h1>
+          <div className="mx-auto grid max-w-sm gap-8 md:max-w-none md:grid-cols-2">
+            <div className="rounded-2xl bg-gray-800 p-6" data-aos="fade-up">
+              <Image src={Product1} alt="Инъекционная смола" width={350} height={288} />
+              <h2 className="mt-4 text-xl font-semibold">Инъекционная смола ALM</h2>
+              <p className="mt-2 text-indigo-200/65">Для герметизации трещин и швов бетона.</p>
+              <p className="mt-2">Цена: 5 000 ₽</p>
+            </div>
+            <div className="rounded-2xl bg-gray-800 p-6" data-aos="fade-up" data-aos-delay={200}>
+              <Image src={Product2} alt="Насос" width={350} height={288} />
+              <h2 className="mt-4 text-xl font-semibold">Насос для инъектирования ALM</h2>
+              <p className="mt-2 text-indigo-200/65">Оборудование для ремонта конструкций.</p>
+              <p className="mt-2">Цена: 35 000 ₽</p>
+            </div>
+          </div>
+          <div className="mt-10 text-center" data-aos="fade-up" data-aos-delay={400}>
+            <Link href="/contact" className="btn bg-linear-to-t from-indigo-600 to-indigo-500 bg-[length:100%_100%] bg-[bottom] text-white shadow-[inset_0px_1px_0px_0px_--theme(--color-white/.16)] hover:bg-[length:100%_150%]">
+              Оставить заявку
+            </Link>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/(default)/contact/page.tsx
+++ b/app/(default)/contact/page.tsx
@@ -1,0 +1,25 @@
+export const metadata = {
+  title: "Контакты - АЛМ",
+  description: "Свяжитесь с нами",
+};
+
+export default function Contact() {
+  return (
+    <section>
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="py-12 md:py-20 text-center">
+          <h1 className="pb-8 font-nacelle text-3xl font-semibold" data-aos="fade-up">
+            Свяжитесь с нами
+          </h1>
+          <p className="mb-6" data-aos="fade-up" data-aos-delay={200}>
+            Телефон: <a href="tel:+74951234567" className="text-indigo-500">+7 (495) 123-45-67</a>
+          </p>
+          <p className="mb-6" data-aos="fade-up" data-aos-delay={400}>
+            Email: <a href="mailto:info@alm-company.ru" className="text-indigo-500">info@alm-company.ru</a>
+          </p>
+          <p data-aos="fade-up" data-aos-delay={600}>Основана 23 сентября 2020 года, г. Москва</p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/cta.tsx
+++ b/components/cta.tsx
@@ -23,16 +23,16 @@ export default function Cta() {
               className="animate-[gradient_6s_linear_infinite] bg-[linear-gradient(to_right,var(--color-gray-200),var(--color-indigo-200),var(--color-gray-50),var(--color-indigo-300),var(--color-gray-200))] bg-[length:200%_auto] bg-clip-text pb-8 font-nacelle text-3xl font-semibold text-transparent md:text-4xl"
               data-aos="fade-up"
             >
-              Join the content-first platform
+              Свяжитесь с нами
             </h2>
             <div className="mx-auto max-w-xs sm:flex sm:max-w-none sm:justify-center">
               <div data-aos="fade-up" data-aos-delay={400}>
                 <a
                   className="btn group mb-4 w-full bg-linear-to-t from-indigo-600 to-indigo-500 bg-[length:100%_100%] bg-[bottom] text-white shadow-[inset_0px_1px_0px_0px_--theme(--color-white/.16)] hover:bg-[length:100%_150%] sm:mb-0 sm:w-auto"
-                  href="#0"
+                  href="tel:+74951234567"
                 >
                   <span className="relative inline-flex items-center">
-                    Start Building
+                    Позвонить
                     <span className="ml-1 tracking-normal text-white/50 transition-transform group-hover:translate-x-0.5">
                       -&gt;
                     </span>
@@ -42,9 +42,9 @@ export default function Cta() {
               <div data-aos="fade-up" data-aos-delay={600}>
                 <a
                   className="btn relative w-full bg-linear-to-b from-gray-800 to-gray-800/60 bg-[length:100%_100%] bg-[bottom] text-gray-300 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:border before:border-transparent before:[background:linear-gradient(to_right,var(--color-gray-800),var(--color-gray-700),var(--color-gray-800))_border-box] before:[mask-composite:exclude_!important] before:[mask:linear-gradient(white_0_0)_padding-box,_linear-gradient(white_0_0)] hover:bg-[length:100%_150%] sm:ml-4 sm:w-auto"
-                  href="#0"
+                  href="/contact"
                 >
-                  Schedule Demo
+                  Написать нам
                 </a>
               </div>
             </div>

--- a/components/hero-home.tsx
+++ b/components/hero-home.tsx
@@ -13,7 +13,7 @@ export default function HeroHome() {
               className="animate-[gradient_6s_linear_infinite] bg-[linear-gradient(to_right,var(--color-gray-200),var(--color-indigo-200),var(--color-gray-50),var(--color-indigo-300),var(--color-gray-200))] bg-[length:200%_auto] bg-clip-text pb-5 font-nacelle text-4xl font-semibold text-transparent md:text-5xl"
               data-aos="fade-up"
             >
-              AI-driven tools for product teams
+              Продукция «АЛМ» для гидроизоляции и ремонта
             </h1>
             <div className="mx-auto max-w-3xl">
               <p
@@ -21,17 +21,18 @@ export default function HeroHome() {
                 data-aos="fade-up"
                 data-aos-delay={200}
               >
-                Our landing page template works on all devices, so you only have
-                to set it up once, and get beautiful results forever.
+                Надёжные решения для инъектирования, восстановления и усиления
+                строительных конструкций. Основана 23 сентября 2020 года,
+                Москва.
               </p>
               <div className="mx-auto max-w-xs sm:flex sm:max-w-none sm:justify-center">
                 <div data-aos="fade-up" data-aos-delay={400}>
                   <a
                     className="btn group mb-4 w-full bg-linear-to-t from-indigo-600 to-indigo-500 bg-[length:100%_100%] bg-[bottom] text-white shadow-[inset_0px_1px_0px_0px_--theme(--color-white/.16)] hover:bg-[length:100%_150%] sm:mb-0 sm:w-auto"
-                    href="#0"
+                    href="tel:+74951234567"
                   >
                     <span className="relative inline-flex items-center">
-                      Start Building
+                      Позвонить
                       <span className="ml-1 tracking-normal text-white/50 transition-transform group-hover:translate-x-0.5">
                         -&gt;
                       </span>
@@ -41,9 +42,9 @@ export default function HeroHome() {
                 <div data-aos="fade-up" data-aos-delay={600}>
                   <a
                     className="btn relative w-full bg-linear-to-b from-gray-800 to-gray-800/60 bg-[length:100%_100%] bg-[bottom] text-gray-300 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:border before:border-transparent before:[background:linear-gradient(to_right,var(--color-gray-800),var(--color-gray-700),var(--color-gray-800))_border-box] before:[mask-composite:exclude_!important] before:[mask:linear-gradient(white_0_0)_padding-box,_linear-gradient(white_0_0)] hover:bg-[length:100%_150%] sm:ml-4 sm:w-auto"
-                    href="#0"
+                    href="/contact"
                   >
-                    Schedule Demo
+                    Обратная связь
                   </a>
                 </div>
               </div>

--- a/components/ui/header.tsx
+++ b/components/ui/header.tsx
@@ -13,22 +13,22 @@ export default function Header() {
             <Logo />
           </div>
 
-          {/* Desktop sign in links */}
+          {/* Navigation links */}
           <ul className="flex flex-1 items-center justify-end gap-3">
             <li>
               <Link
-                href="/signin"
+                href="/catalog"
                 className="btn-sm relative bg-linear-to-b from-gray-800 to-gray-800/60 bg-[length:100%_100%] bg-[bottom] py-[5px] text-gray-300 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:border before:border-transparent before:[background:linear-gradient(to_right,var(--color-gray-800),var(--color-gray-700),var(--color-gray-800))_border-box] before:[mask-composite:exclude_!important] before:[mask:linear-gradient(white_0_0)_padding-box,_linear-gradient(white_0_0)] hover:bg-[length:100%_150%]"
               >
-                Sign In
+                Каталог
               </Link>
             </li>
             <li>
               <Link
-                href="/signup"
+                href="/contact"
                 className="btn-sm bg-linear-to-t from-indigo-600 to-indigo-500 bg-[length:100%_100%] bg-[bottom] py-[5px] text-white shadow-[inset_0px_1px_0px_0px_--theme(--color-white/.16)] hover:bg-[length:100%_150%]"
               >
-                Register
+                Контакты
               </Link>
             </li>
           </ul>

--- a/components/ui/logo.tsx
+++ b/components/ui/logo.tsx
@@ -4,8 +4,8 @@ import logo from "@/public/images/logo.svg";
 
 export default function Logo() {
   return (
-    <Link href="/" className="inline-flex shrink-0" aria-label="Cruip">
-      <Image src={logo} alt="Cruip Logo" width={32} height={32} />
+    <Link href="/" className="inline-flex shrink-0" aria-label="АЛМ">
+      <Image src={logo} alt="АЛМ" width={32} height={32} />
     </Link>
   );
 }


### PR DESCRIPTION
## Summary
- add product catalog and contact pages
- localize hero section and CTA
- update header navigation for catalog and contacts
- tweak logo alt text

## Testing
- `pnpm exec next lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68811ff0138083309a4f43a7b309080b