### PR TITLE
Change dark theme to light

### DIFF
--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -20,7 +20,7 @@ export default function ResetPassword() {
           <form className="mx-auto max-w-[400px]">
             <div>
               <label
-                className="mb-1 block text-sm font-medium text-indigo-200/65"
+                className="mb-1 block text-sm font-medium text-gray-600"
                 htmlFor="email"
               >
                 Email

--- a/app/(auth)/signin/page.tsx
+++ b/app/(auth)/signin/page.tsx
@@ -21,7 +21,7 @@ export default function SignIn() {
             <div className="space-y-5">
               <div>
                 <label
-                  className="mb-1 block text-sm font-medium text-indigo-200/65"
+                  className="mb-1 block text-sm font-medium text-gray-600"
                   htmlFor="email"
                 >
                   Email
@@ -36,7 +36,7 @@ export default function SignIn() {
               <div>
                 <div className="mb-1 flex items-center justify-between gap-3">
                   <label
-                    className="block text-sm font-medium text-indigo-200/65"
+                    className="block text-sm font-medium text-gray-600"
                     htmlFor="password"
                   >
                     Пароль
@@ -69,7 +69,7 @@ export default function SignIn() {
             </div>
           </form>
           {/* Bottom link */}
-          <div className="mt-6 text-center text-sm text-indigo-200/65">
+          <div className="mt-6 text-center text-sm text-gray-600">
             Нет аккаунта?{' '}
             <Link className="font-medium text-indigo-500" href="/signup">
               Зарегистрируйтесь

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -21,7 +21,7 @@ export default function SignUp() {
             <div className="space-y-5">
               <div>
                 <label
-                  className="mb-1 block text-sm font-medium text-indigo-200/65"
+                  className="mb-1 block text-sm font-medium text-gray-600"
                   htmlFor="name"
                 >
                   Имя <span className="text-red-500">*</span>
@@ -36,7 +36,7 @@ export default function SignUp() {
               </div>
               <div>
                 <label
-                  className="mb-1 block text-sm font-medium text-indigo-200/65"
+                  className="mb-1 block text-sm font-medium text-gray-600"
                   htmlFor="name"
                 >
                   Название компании <span className="text-red-500">*</span>
@@ -51,7 +51,7 @@ export default function SignUp() {
               </div>
               <div>
                 <label
-                  className="mb-1 block text-sm font-medium text-indigo-200/65"
+                  className="mb-1 block text-sm font-medium text-gray-600"
                   htmlFor="email"
                 >
                   Рабочий email <span className="text-red-500">*</span>
@@ -65,7 +65,7 @@ export default function SignUp() {
               </div>
               <div>
                 <label
-                  className="block text-sm font-medium text-indigo-200/65"
+                  className="block text-sm font-medium text-gray-600"
                   htmlFor="password"
                 >
                   Пароль <span className="text-red-500">*</span>
@@ -91,7 +91,7 @@ export default function SignUp() {
             </div>
           </form>
           {/* Bottom link */}
-          <div className="mt-6 text-center text-sm text-indigo-200/65">
+          <div className="mt-6 text-center text-sm text-gray-600">
             Уже есть аккаунт?{' '}
             <Link className="font-medium text-indigo-500" href="/signin">
               Войти

--- a/app/(default)/catalog/page.tsx
+++ b/app/(default)/catalog/page.tsx
@@ -17,16 +17,16 @@ export default function Catalog() {
             Каталог продукции «АЛМ»
           </h1>
           <div className="mx-auto grid max-w-sm gap-8 md:max-w-none md:grid-cols-2">
-            <div className="rounded-2xl bg-gray-800 p-6" data-aos="fade-up">
+            <div className="rounded-2xl bg-white p-6 shadow" data-aos="fade-up">
               <Image src={Product1} alt="Инъекционная смола" width={350} height={288} />
               <h2 className="mt-4 text-xl font-semibold">Инъекционная смола ALM</h2>
-              <p className="mt-2 text-indigo-200/65">Для герметизации трещин и швов бетона.</p>
+              <p className="mt-2 text-gray-600">Для герметизации трещин и швов бетона.</p>
               <p className="mt-2">Цена: 5 000 ₽</p>
             </div>
-            <div className="rounded-2xl bg-gray-800 p-6" data-aos="fade-up" data-aos-delay={200}>
+            <div className="rounded-2xl bg-white p-6 shadow" data-aos="fade-up" data-aos-delay={200}>
               <Image src={Product2} alt="Насос" width={350} height={288} />
               <h2 className="mt-4 text-xl font-semibold">Насос для инъектирования ALM</h2>
-              <p className="mt-2 text-indigo-200/65">Оборудование для ремонта конструкций.</p>
+              <p className="mt-2 text-gray-600">Оборудование для ремонта конструкций.</p>
               <p className="mt-2">Цена: 35 000 ₽</p>
             </div>
           </div>

--- a/app/css/additional-styles/utility-patterns.css
+++ b/app/css/additional-styles/utility-patterns.css
@@ -26,14 +26,14 @@ input[type='search']::-webkit-search-results-decoration {
 .form-select,
 .form-checkbox,
 .form-radio {
-    @apply border border-gray-700 bg-gray-900/50 focus:border-gray-600 focus:ring-0 focus:ring-offset-0;
+    @apply border border-gray-300 bg-white focus:border-gray-400 focus:ring-0 focus:ring-offset-0;
 }
 
 .form-input,
 .form-textarea,
 .form-multiselect,
 .form-select {
-    @apply rounded-lg px-4 py-2.5 text-sm text-gray-200;
+    @apply rounded-lg px-4 py-2.5 text-sm text-gray-800;
 }
 
 .form-input,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -51,7 +51,7 @@ export default function RootLayout({
   return (
     <html lang="ru">
       <body
-        className={`${inter.variable} ${nacelle.variable} bg-gray-950 font-inter text-base text-gray-200 antialiased`}
+        className={`${inter.variable} ${nacelle.variable} bg-white font-inter text-base text-gray-800 antialiased`}
       >
         <div className="flex min-h-screen flex-col overflow-hidden supports-[overflow:clip]:overflow-clip">
           <Header />

--- a/components/cta.tsx
+++ b/components/cta.tsx
@@ -41,7 +41,7 @@ export default function Cta() {
               </div>
               <div data-aos="fade-up" data-aos-delay={600}>
                 <a
-                  className="btn relative w-full bg-linear-to-b from-gray-800 to-gray-800/60 bg-[length:100%_100%] bg-[bottom] text-gray-300 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:border before:border-transparent before:[background:linear-gradient(to_right,var(--color-gray-800),var(--color-gray-700),var(--color-gray-800))_border-box] before:[mask-composite:exclude_!important] before:[mask:linear-gradient(white_0_0)_padding-box,_linear-gradient(white_0_0)] hover:bg-[length:100%_150%] sm:ml-4 sm:w-auto"
+                  className="btn relative w-full bg-white text-gray-800 border border-gray-300 hover:bg-gray-50 sm:ml-4 sm:w-auto"
                   href="/contact"
                 >
                   Написать нам

--- a/components/features.tsx
+++ b/components/features.tsx
@@ -42,7 +42,7 @@ export default function Features() {
             <h2 className="animate-[gradient_6s_linear_infinite] bg-[linear-gradient(to_right,var(--color-gray-200),var(--color-indigo-200),var(--color-gray-50),var(--color-indigo-300),var(--color-gray-200))] bg-[length:200%_auto] bg-clip-text pb-4 font-nacelle text-3xl font-semibold text-transparent md:text-4xl">
               Создано для современных команд
             </h2>
-            <p className="text-lg text-indigo-200/65">
+            <p className="text-lg text-gray-600">
               Open AI читает и понимает ваши файлы, и одной строки обратной
               связи достаточно, чтобы вы могли двигаться быстрее мысли.
             </p>
@@ -71,10 +71,10 @@ export default function Features() {
                   d="m16.295 5.393 7.528 2.034-4.436 16.412L5.87 20.185l.522-1.93 11.585 3.132 3.392-12.55-5.597-1.514.522-1.93Z"
                 />
               </svg>
-              <h3 className="mb-1 font-nacelle text-[1rem] font-semibold text-gray-200">
+              <h3 className="mb-1 font-nacelle text-[1rem] font-semibold text-gray-800">
                 Контроль этапов
               </h3>
-              <p className="text-indigo-200/65">
+              <p className="text-gray-600">
                 Отслеживайте прогресс в индивидуальных процессах вашей команды и
                 находите баланс между удобством, конфиденциальностью и
                 безопасностью.
@@ -90,10 +90,10 @@ export default function Features() {
                 <path fillOpacity=".48" d="M7 8V0H5v8h2Zm12 16v-4h-2v4h2Z" />
                 <path d="M19 6H0v2h17v8H7v-6H5v8h19v-2h-5V6Z" />
               </svg>
-              <h3 className="mb-1 font-nacelle text-[1rem] font-semibold text-gray-200">
+              <h3 className="mb-1 font-nacelle text-[1rem] font-semibold text-gray-800">
                 Рабочие панели
               </h3>
-              <p className="text-indigo-200/65">
+              <p className="text-gray-600">
                 Отслеживайте прогресс в индивидуальных процессах вашей команды и
                 находите баланс между удобством, конфиденциальностью и
                 безопасностью.
@@ -112,10 +112,10 @@ export default function Features() {
                   d="M13.01 12.508a2.5 2.5 0 0 0-3.502.482L1.797 23.16.203 21.952l7.71-10.17a4.5 4.5 0 1 1 7.172 5.437l-4.84 6.386-1.594-1.209 4.841-6.385a2.5 2.5 0 0 0-.482-3.503Z"
                 />
               </svg>
-              <h3 className="mb-1 font-nacelle text-[1rem] font-semibold text-gray-200">
+              <h3 className="mb-1 font-nacelle text-[1rem] font-semibold text-gray-800">
                 Расширенный поиск
               </h3>
-              <p className="text-indigo-200/65">
+              <p className="text-gray-600">
                 Отслеживайте прогресс в индивидуальных процессах вашей команды и
                 находите баланс между удобством, конфиденциальностью и
                 безопасностью.
@@ -139,10 +139,10 @@ export default function Features() {
                 />
                 <path d="m16.321 2-.5-.866 1.733-1 .5.866A22 22 0 0 1 21 12c0 3.852-1.017 7.636-2.948 10.97l-.502.865-1.73-1.003.501-.865A19.878 19.878 0 0 0 19 12a20 20 0 0 0-2.679-10Z" />
               </svg>
-              <h3 className="mb-1 font-nacelle text-[1rem] font-semibold text-gray-200">
+              <h3 className="mb-1 font-nacelle text-[1rem] font-semibold text-gray-800">
                 Стратегические инициативы
               </h3>
-              <p className="text-indigo-200/65">
+              <p className="text-gray-600">
                 Отслеживайте прогресс в индивидуальных процессах вашей команды и
                 находите баланс между удобством, конфиденциальностью и
                 безопасностью.
@@ -161,10 +161,10 @@ export default function Features() {
                 />
                 <path d="m7.454 2.891.891-.454L7.437.655l-.891.454a12 12 0 0 0 0 21.382l.89.454.91-1.781-.892-.455a10 10 0 0 1 0-17.818ZM17.456 1.11l-.891-.454-.909 1.782.891.454a10 10 0 0 1 0 17.819l-.89.454.908 1.781.89-.454a12 12 0 0 0 0-21.382Z" />
               </svg>
-              <h3 className="mb-1 font-nacelle text-[1rem] font-semibold text-gray-200">
+              <h3 className="mb-1 font-nacelle text-[1rem] font-semibold text-gray-800">
                 Гибкие процессы
               </h3>
-              <p className="text-indigo-200/65">
+              <p className="text-gray-600">
                 Отслеживайте прогресс в индивидуальных процессах вашей команды и
                 находите баланс между удобством, конфиденциальностью и
                 безопасностью.
@@ -183,10 +183,10 @@ export default function Features() {
                 />
                 <path d="M19.406 3.844 6.083 20.497.586 15 2 13.586l3.917 3.917L17.844 2.595l1.562 1.25Z" />
               </svg>
-              <h3 className="mb-1 font-nacelle text-[1rem] font-semibold text-gray-200">
+              <h3 className="mb-1 font-nacelle text-[1rem] font-semibold text-gray-800">
                 Общая шкала времени
               </h3>
-              <p className="text-indigo-200/65">
+              <p className="text-gray-600">
                 Отслеживайте прогресс в индивидуальных процессах вашей команды и
                 находите баланс между удобством, конфиденциальностью и
                 безопасностью.

--- a/components/hero-home.tsx
+++ b/components/hero-home.tsx
@@ -17,7 +17,7 @@ export default function HeroHome() {
             </h1>
             <div className="mx-auto max-w-3xl">
               <p
-                className="mb-8 text-xl text-indigo-200/65"
+                className="mb-8 text-xl text-gray-600"
                 data-aos="fade-up"
                 data-aos-delay={200}
               >
@@ -41,7 +41,7 @@ export default function HeroHome() {
                 </div>
                 <div data-aos="fade-up" data-aos-delay={600}>
                   <a
-                    className="btn relative w-full bg-linear-to-b from-gray-800 to-gray-800/60 bg-[length:100%_100%] bg-[bottom] text-gray-300 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:border before:border-transparent before:[background:linear-gradient(to_right,var(--color-gray-800),var(--color-gray-700),var(--color-gray-800))_border-box] before:[mask-composite:exclude_!important] before:[mask:linear-gradient(white_0_0)_padding-box,_linear-gradient(white_0_0)] hover:bg-[length:100%_150%] sm:ml-4 sm:w-auto"
+                    className="btn relative w-full bg-white text-gray-800 border border-gray-300 hover:bg-gray-50 sm:ml-4 sm:w-auto"
                     href="/contact"
                   >
                     Обратная связь

--- a/components/modal-video.tsx
+++ b/components/modal-video.tsx
@@ -65,7 +65,7 @@ export default function ModalVideo({
           />
         </figure>
         {/* Play icon */}
-        <span className="pointer-events-none absolute p-2.5 before:absolute before:inset-0 before:rounded-full before:bg-gray-950 before:duration-300 group-hover:before:scale-110">
+        <span className="pointer-events-none absolute p-2.5 before:absolute before:inset-0 before:rounded-full before:bg-white before:duration-300 group-hover:before:scale-110">
           <span className="relative flex items-center gap-3">
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -93,7 +93,7 @@ export default function ModalVideo({
                 </linearGradient>
               </defs>
             </svg>
-            <span className="text-sm font-medium leading-tight text-gray-300">
+            <span className="text-sm font-medium leading-tight text-gray-700">
               Watch Demo
               <span className="text-gray-600"> - </span>
               3:47

--- a/components/testimonials.tsx
+++ b/components/testimonials.tsx
@@ -118,7 +118,7 @@ export default function Testimonials() {
           <h2 className="animate-[gradient_6s_linear_infinite] bg-[linear-gradient(to_right,var(--color-gray-200),var(--color-indigo-200),var(--color-gray-50),var(--color-indigo-300),var(--color-gray-200))] bg-[length:200%_auto] bg-clip-text pb-4 font-nacelle text-3xl font-semibold text-transparent md:text-4xl">
             Не верьте нам на слово
           </h2>
-          <p className="text-lg text-indigo-200/65">
+          <p className="text-lg text-gray-600">
             Мы предлагаем технологичные решения, которые помогают руководителям
             создавать более комфортные и здоровые рабочие пространства по всему
             миру.
@@ -128,7 +128,7 @@ export default function Testimonials() {
         <div>
           {/* Buttons */}
           <div className="flex justify-center pb-12 max-md:hidden md:pb-16">
-            <div className="relative inline-flex flex-wrap justify-center rounded-[1.25rem] bg-gray-800/40 p-1">
+            <div className="relative inline-flex flex-wrap justify-center rounded-[1.25rem] bg-gray-200/40 p-1">
               {/* Button #1 */}
               <button
                 className={`flex h-8 flex-1 items-center gap-2.5 whitespace-nowrap rounded-full px-3 text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-3 focus-visible:ring-indigo-200 ${category === 1 ? "relative bg-linear-to-b from-gray-900 via-gray-800/60 to-gray-900 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:border before:border-transparent before:[background:linear-gradient(to_bottom,--theme(--color-indigo-500/0),--theme(--color-indigo-500/.5))_border-box] before:[mask-composite:exclude_!important] before:[mask:linear-gradient(white_0_0)_padding-box,_linear-gradient(white_0_0)]" : "opacity-65 transition-opacity hover:opacity-90"}`}
@@ -255,7 +255,7 @@ export function Testimonial({
         <div>
           <Image src={testimonial.clientImg} height={36} alt="Client logo" />
         </div>
-        <p className="text-indigo-200/65 before:content-['“'] after:content-['”']">
+        <p className="text-gray-600 before:content-['“'] after:content-['”']">
           {children}
         </p>
         <div className="flex items-center gap-3">
@@ -266,11 +266,11 @@ export function Testimonial({
             height={36}
             alt={testimonial.name}
           />
-          <div className="text-sm font-medium text-gray-200">
+          <div className="text-sm font-medium text-gray-800">
             <span>{testimonial.name}</span>
             <span className="text-gray-700"> - </span>
             <a
-              className="text-indigo-200/65 transition-colors hover:text-indigo-500"
+              className="text-gray-600 transition-colors hover:text-indigo-500"
               href="#0"
             >
               {testimonial.company}

--- a/components/ui/footer.tsx
+++ b/components/ui/footer.tsx
@@ -22,11 +22,11 @@ export default function Footer() {
         <div className="grid grid-cols-2 justify-between gap-12 py-8 sm:grid-rows-[auto_auto] md:grid-cols-4 md:grid-rows-[auto_auto] md:py-12 lg:grid-cols-[repeat(4,minmax(0,140px))_1fr] lg:grid-rows-1 xl:gap-20">
           {/* 1st block */}
           <div className="space-y-2">
-            <h3 className="text-sm font-medium text-gray-200">Продукт</h3>
+            <h3 className="text-sm font-medium text-gray-800">Продукт</h3>
             <ul className="space-y-2 text-sm">
               <li>
                 <a
-                  className="text-indigo-200/65 transition hover:text-indigo-500"
+                  className="text-gray-600 transition hover:text-indigo-500"
                   href="#0"
                 >
                   Возможности
@@ -34,7 +34,7 @@ export default function Footer() {
               </li>
               <li>
                 <a
-                  className="text-indigo-200/65 transition hover:text-indigo-500"
+                  className="text-gray-600 transition hover:text-indigo-500"
                   href="#0"
                 >
                   Интеграции
@@ -42,7 +42,7 @@ export default function Footer() {
               </li>
               <li>
                 <a
-                  className="text-indigo-200/65 transition hover:text-indigo-500"
+                  className="text-gray-600 transition hover:text-indigo-500"
                   href="#0"
                 >
                   Цены и тарифы
@@ -50,7 +50,7 @@ export default function Footer() {
               </li>
               <li>
                 <a
-                  className="text-indigo-200/65 transition hover:text-indigo-500"
+                  className="text-gray-600 transition hover:text-indigo-500"
                   href="#0"
                 >
                   История изменений
@@ -58,7 +58,7 @@ export default function Footer() {
               </li>
               <li>
                 <a
-                  className="text-indigo-200/65 transition hover:text-indigo-500"
+                  className="text-gray-600 transition hover:text-indigo-500"
                   href="#0"
                 >
                   Наш метод
@@ -66,7 +66,7 @@ export default function Footer() {
               </li>
               <li>
                 <a
-                  className="text-indigo-200/65 transition hover:text-indigo-500"
+                  className="text-gray-600 transition hover:text-indigo-500"
                   href="#0"
                 >
                   Пользовательское соглашение
@@ -76,11 +76,11 @@ export default function Footer() {
           </div>
           {/* 2nd block */}
           <div className="space-y-2">
-            <h3 className="text-sm font-medium text-gray-200">Компания</h3>
+            <h3 className="text-sm font-medium text-gray-800">Компания</h3>
             <ul className="space-y-2 text-sm">
               <li>
                 <a
-                  className="text-indigo-200/65 transition hover:text-indigo-500"
+                  className="text-gray-600 transition hover:text-indigo-500"
                   href="#0"
                 >
                   О нас
@@ -88,7 +88,7 @@ export default function Footer() {
               </li>
               <li>
                 <a
-                  className="text-indigo-200/65 transition hover:text-indigo-500"
+                  className="text-gray-600 transition hover:text-indigo-500"
                   href="#0"
                 >
                   Разнообразие и инклюзивность
@@ -96,7 +96,7 @@ export default function Footer() {
               </li>
               <li>
                 <a
-                  className="text-indigo-200/65 transition hover:text-indigo-500"
+                  className="text-gray-600 transition hover:text-indigo-500"
                   href="#0"
                 >
                   Блог
@@ -104,7 +104,7 @@ export default function Footer() {
               </li>
               <li>
                 <a
-                  className="text-indigo-200/65 transition hover:text-indigo-500"
+                  className="text-gray-600 transition hover:text-indigo-500"
                   href="#0"
                 >
                   Вакансии
@@ -112,7 +112,7 @@ export default function Footer() {
               </li>
               <li>
                 <a
-                  className="text-indigo-200/65 transition hover:text-indigo-500"
+                  className="text-gray-600 transition hover:text-indigo-500"
                   href="#0"
                 >
                   Финансовые отчёты
@@ -122,11 +122,11 @@ export default function Footer() {
           </div>
           {/* 3rd block */}
           <div className="space-y-2">
-            <h3 className="text-sm font-medium text-gray-200">Ресурсы</h3>
+            <h3 className="text-sm font-medium text-gray-800">Ресурсы</h3>
             <ul className="space-y-2 text-sm">
               <li>
                 <a
-                  className="text-indigo-200/65 transition hover:text-indigo-500"
+                  className="text-gray-600 transition hover:text-indigo-500"
                   href="#0"
                 >
                   Сообщество
@@ -134,7 +134,7 @@ export default function Footer() {
               </li>
               <li>
                 <a
-                  className="text-indigo-200/65 transition hover:text-indigo-500"
+                  className="text-gray-600 transition hover:text-indigo-500"
                   href="#0"
                 >
                   Условия использования
@@ -142,7 +142,7 @@ export default function Footer() {
               </li>
               <li>
                 <a
-                  className="text-indigo-200/65 transition hover:text-indigo-500"
+                  className="text-gray-600 transition hover:text-indigo-500"
                   href="#0"
                 >
                   Сообщить об уязвимости
@@ -152,13 +152,13 @@ export default function Footer() {
           </div>
           {/* 4th block */}
           <div className="space-y-2">
-            <h3 className="text-sm font-medium text-gray-200">
+            <h3 className="text-sm font-medium text-gray-800">
               Библиотека контента
             </h3>
             <ul className="space-y-2 text-sm">
               <li>
                 <a
-                  className="text-indigo-200/65 transition hover:text-indigo-500"
+                  className="text-gray-600 transition hover:text-indigo-500"
                   href="#0"
                 >
                   Шаблоны
@@ -166,7 +166,7 @@ export default function Footer() {
               </li>
               <li>
                 <a
-                  className="text-indigo-200/65 transition hover:text-indigo-500"
+                  className="text-gray-600 transition hover:text-indigo-500"
                   href="#0"
                 >
                   Руководства
@@ -174,7 +174,7 @@ export default function Footer() {
               </li>
               <li>
                 <a
-                  className="text-indigo-200/65 transition hover:text-indigo-500"
+                  className="text-gray-600 transition hover:text-indigo-500"
                   href="#0"
                 >
                   База знаний
@@ -182,7 +182,7 @@ export default function Footer() {
               </li>
               <li>
                 <a
-                  className="text-indigo-200/65 transition hover:text-indigo-500"
+                  className="text-gray-600 transition hover:text-indigo-500"
                   href="#0"
                 >
                   Обучение
@@ -190,7 +190,7 @@ export default function Footer() {
               </li>
               <li>
                 <a
-                  className="text-indigo-200/65 transition hover:text-indigo-500"
+                  className="text-gray-600 transition hover:text-indigo-500"
                   href="#0"
                 >
                   Управление cookies
@@ -204,11 +204,11 @@ export default function Footer() {
               <Logo />
             </div>
             <div className="text-sm">
-              <p className="mb-3 text-indigo-200/65">
+              <p className="mb-3 text-gray-600">
                 © Cruip.com
                 <span className="text-gray-700"> · </span>
                 <a
-                  className="text-indigo-200/65 transition hover:text-indigo-500"
+                  className="text-gray-600 transition hover:text-indigo-500"
                   href="#0"
                 >
                   Условия

--- a/components/ui/header.tsx
+++ b/components/ui/header.tsx
@@ -7,7 +7,7 @@ export default function Header() {
   return (
     <header className="z-30 mt-2 w-full md:mt-5">
       <div className="mx-auto max-w-6xl px-4 sm:px-6">
-        <div className="relative flex h-14 items-center justify-between gap-3 rounded-2xl bg-gray-900/90 px-3 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:border before:border-transparent before:[background:linear-gradient(to_right,var(--color-gray-800),var(--color-gray-700),var(--color-gray-800))_border-box] before:[mask-composite:exclude_!important] before:[mask:linear-gradient(white_0_0)_padding-box,_linear-gradient(white_0_0)] after:absolute after:inset-0 after:-z-10 after:backdrop-blur-xs">
+        <div className="relative flex h-14 items-center justify-between gap-3 rounded-2xl bg-white/90 px-3 shadow">
           {/* Site branding */}
           <div className="flex flex-1 items-center">
             <Logo />
@@ -18,7 +18,7 @@ export default function Header() {
             <li>
               <Link
                 href="/catalog"
-                className="btn-sm relative bg-linear-to-b from-gray-800 to-gray-800/60 bg-[length:100%_100%] bg-[bottom] py-[5px] text-gray-300 before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:border before:border-transparent before:[background:linear-gradient(to_right,var(--color-gray-800),var(--color-gray-700),var(--color-gray-800))_border-box] before:[mask-composite:exclude_!important] before:[mask:linear-gradient(white_0_0)_padding-box,_linear-gradient(white_0_0)] hover:bg-[length:100%_150%]"
+                className="btn-sm bg-white py-[5px] text-gray-800 border border-gray-300 hover:bg-gray-50"
               >
                 Каталог
               </Link>

--- a/components/workflows.tsx
+++ b/components/workflows.tsx
@@ -19,7 +19,7 @@ export default function Workflows() {
             <h2 className="animate-[gradient_6s_linear_infinite] bg-[linear-gradient(to_right,var(--color-gray-200),var(--color-indigo-200),var(--color-gray-50),var(--color-indigo-300),var(--color-gray-200))] bg-[length:200%_auto] bg-clip-text pb-4 font-nacelle text-3xl font-semibold text-transparent md:text-4xl">
               Планируйте путь продукта
             </h2>
-            <p className="text-lg text-indigo-200/65">
+            <p className="text-lg text-gray-600">
               Простой и удобный интерфейс для начала совместной работы с командой
               за считанные минуты. Легко интегрируется с вашим кодом и любимыми
               языками программирования.
@@ -29,13 +29,13 @@ export default function Workflows() {
           <Spotlight className="group mx-auto grid max-w-sm items-start gap-6 lg:max-w-none lg:grid-cols-3">
             {/* Card 1 */}
             <a
-              className="group/card relative h-full overflow-hidden rounded-2xl bg-gray-800 p-px before:pointer-events-none before:absolute before:-left-40 before:-top-40 before:z-10 before:h-80 before:w-80 before:translate-x-[var(--mouse-x)] before:translate-y-[var(--mouse-y)] before:rounded-full before:bg-indigo-500/80 before:opacity-0 before:blur-3xl before:transition-opacity before:duration-500 after:pointer-events-none after:absolute after:-left-48 after:-top-48 after:z-30 after:h-64 after:w-64 after:translate-x-[var(--mouse-x)] after:translate-y-[var(--mouse-y)] after:rounded-full after:bg-indigo-500 after:opacity-0 after:blur-3xl after:transition-opacity after:duration-500 hover:after:opacity-20 group-hover:before:opacity-100"
+              className="group/card relative h-full overflow-hidden rounded-2xl bg-gray-100 p-px before:pointer-events-none before:absolute before:-left-40 before:-top-40 before:z-10 before:h-80 before:w-80 before:translate-x-[var(--mouse-x)] before:translate-y-[var(--mouse-y)] before:rounded-full before:bg-indigo-500/80 before:opacity-0 before:blur-3xl before:transition-opacity before:duration-500 after:pointer-events-none after:absolute after:-left-48 after:-top-48 after:z-30 after:h-64 after:w-64 after:translate-x-[var(--mouse-x)] after:translate-y-[var(--mouse-y)] after:rounded-full after:bg-indigo-500 after:opacity-0 after:blur-3xl after:transition-opacity after:duration-500 hover:after:opacity-20 group-hover:before:opacity-100"
               href="#0"
             >
-              <div className="relative z-20 h-full overflow-hidden rounded-[inherit] bg-gray-950 after:absolute after:inset-0 after:bg-linear-to-br after:from-gray-900/50 after:via-gray-800/25 after:to-gray-900/50">
+              <div className="relative z-20 h-full overflow-hidden rounded-[inherit] bg-white after:absolute after:inset-0 after:bg-white">
                 {/* Arrow */}
                 <div
-                  className="absolute right-6 top-6 flex h-8 w-8 items-center justify-center rounded-full border border-gray-700/50 bg-gray-800/65 text-gray-200 opacity-0 transition-opacity group-hover/card:opacity-100"
+                  className="absolute right-6 top-6 flex h-8 w-8 items-center justify-center rounded-full border border-gray-300 bg-gray-200 text-gray-600 opacity-0 transition-opacity group-hover/card:opacity-100"
                   aria-hidden="true"
                 >
                   <svg
@@ -61,13 +61,13 @@ export default function Workflows() {
                 {/* Content */}
                 <div className="p-6">
                   <div className="mb-3">
-                    <span className="btn-sm relative rounded-full bg-gray-800/40 px-2.5 py-0.5 text-xs font-normal before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:border before:border-transparent before:[background:linear-gradient(to_bottom,--theme(--color-gray-700/.15),--theme(--color-gray-700/.5))_border-box] before:[mask-composite:exclude_!important] before:[mask:linear-gradient(white_0_0)_padding-box,_linear-gradient(white_0_0)] hover:bg-gray-800/60">
+                    <span className="btn-sm relative rounded-full bg-gray-200/40 px-2.5 py-0.5 text-xs font-normal before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:border before:border-transparent before:[background:linear-gradient(to_bottom,#e5e7eb,#e5e7eb)] before:[mask-composite:exclude_!important] before:[mask:linear-gradient(white_0_0)_padding-box,_linear-gradient(white_0_0)] hover:bg-gray-200/60">
                       <span className="bg-linear-to-r from-indigo-500 to-indigo-200 bg-clip-text text-transparent">
                         Встроенные инструменты
                       </span>
                     </span>
                   </div>
-                  <p className="text-indigo-200/65">
+                  <p className="text-gray-600">
                     Оптимизируйте разработку продукта с помощью платформы,
                     объединяющей спецификации и инсайты.
                   </p>
@@ -76,13 +76,13 @@ export default function Workflows() {
             </a>
             {/* Card 2 */}
             <a
-              className="group/card relative h-full overflow-hidden rounded-2xl bg-gray-800 p-px before:pointer-events-none before:absolute before:-left-40 before:-top-40 before:z-10 before:h-80 before:w-80 before:translate-x-[var(--mouse-x)] before:translate-y-[var(--mouse-y)] before:rounded-full before:bg-indigo-500/80 before:opacity-0 before:blur-3xl before:transition-opacity before:duration-500 after:pointer-events-none after:absolute after:-left-48 after:-top-48 after:z-30 after:h-64 after:w-64 after:translate-x-[var(--mouse-x)] after:translate-y-[var(--mouse-y)] after:rounded-full after:bg-indigo-500 after:opacity-0 after:blur-3xl after:transition-opacity after:duration-500 hover:after:opacity-20 group-hover:before:opacity-100"
+              className="group/card relative h-full overflow-hidden rounded-2xl bg-gray-100 p-px before:pointer-events-none before:absolute before:-left-40 before:-top-40 before:z-10 before:h-80 before:w-80 before:translate-x-[var(--mouse-x)] before:translate-y-[var(--mouse-y)] before:rounded-full before:bg-indigo-500/80 before:opacity-0 before:blur-3xl before:transition-opacity before:duration-500 after:pointer-events-none after:absolute after:-left-48 after:-top-48 after:z-30 after:h-64 after:w-64 after:translate-x-[var(--mouse-x)] after:translate-y-[var(--mouse-y)] after:rounded-full after:bg-indigo-500 after:opacity-0 after:blur-3xl after:transition-opacity after:duration-500 hover:after:opacity-20 group-hover:before:opacity-100"
               href="#0"
             >
-              <div className="relative z-20 h-full overflow-hidden rounded-[inherit] bg-gray-950 after:absolute after:inset-0 after:bg-linear-to-br after:from-gray-900/50 after:via-gray-800/25 after:to-gray-900/50">
+              <div className="relative z-20 h-full overflow-hidden rounded-[inherit] bg-white after:absolute after:inset-0 after:bg-white">
                 {/* Arrow */}
                 <div
-                  className="absolute right-6 top-6 flex h-8 w-8 items-center justify-center rounded-full border border-gray-700/50 bg-gray-800/65 text-gray-200 opacity-0 transition-opacity group-hover/card:opacity-100"
+                  className="absolute right-6 top-6 flex h-8 w-8 items-center justify-center rounded-full border border-gray-300 bg-gray-200 text-gray-600 opacity-0 transition-opacity group-hover/card:opacity-100"
                   aria-hidden="true"
                 >
                   <svg
@@ -108,13 +108,13 @@ export default function Workflows() {
                 {/* Content */}
                 <div className="p-6">
                   <div className="mb-3">
-                    <span className="btn-sm relative rounded-full bg-gray-800/40 px-2.5 py-0.5 text-xs font-normal before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:border before:border-transparent before:[background:linear-gradient(to_bottom,--theme(--color-gray-700/.15),--theme(--color-gray-700/.5))_border-box] before:[mask-composite:exclude_!important] before:[mask:linear-gradient(white_0_0)_padding-box,_linear-gradient(white_0_0)] hover:bg-gray-800/60">
+                    <span className="btn-sm relative rounded-full bg-gray-200/40 px-2.5 py-0.5 text-xs font-normal before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:border before:border-transparent before:[background:linear-gradient(to_bottom,#e5e7eb,#e5e7eb)] before:[mask-composite:exclude_!important] before:[mask:linear-gradient(white_0_0)_padding-box,_linear-gradient(white_0_0)] hover:bg-gray-200/60">
                       <span className="bg-linear-to-r from-indigo-500 to-indigo-200 bg-clip-text text-transparent">
                         Мгновенное масштабирование
                       </span>
                     </span>
                   </div>
-                  <p className="text-indigo-200/65">
+                  <p className="text-gray-600">
                     Оптимизируйте разработку продукта с помощью платформы,
                     объединяющей спецификации и инсайты.
                   </p>
@@ -123,13 +123,13 @@ export default function Workflows() {
             </a>
             {/* Card 3 */}
             <a
-              className="group/card relative h-full overflow-hidden rounded-2xl bg-gray-800 p-px before:pointer-events-none before:absolute before:-left-40 before:-top-40 before:z-10 before:h-80 before:w-80 before:translate-x-[var(--mouse-x)] before:translate-y-[var(--mouse-y)] before:rounded-full before:bg-indigo-500/80 before:opacity-0 before:blur-3xl before:transition-opacity before:duration-500 after:pointer-events-none after:absolute after:-left-48 after:-top-48 after:z-30 after:h-64 after:w-64 after:translate-x-[var(--mouse-x)] after:translate-y-[var(--mouse-y)] after:rounded-full after:bg-indigo-500 after:opacity-0 after:blur-3xl after:transition-opacity after:duration-500 hover:after:opacity-20 group-hover:before:opacity-100"
+              className="group/card relative h-full overflow-hidden rounded-2xl bg-gray-100 p-px before:pointer-events-none before:absolute before:-left-40 before:-top-40 before:z-10 before:h-80 before:w-80 before:translate-x-[var(--mouse-x)] before:translate-y-[var(--mouse-y)] before:rounded-full before:bg-indigo-500/80 before:opacity-0 before:blur-3xl before:transition-opacity before:duration-500 after:pointer-events-none after:absolute after:-left-48 after:-top-48 after:z-30 after:h-64 after:w-64 after:translate-x-[var(--mouse-x)] after:translate-y-[var(--mouse-y)] after:rounded-full after:bg-indigo-500 after:opacity-0 after:blur-3xl after:transition-opacity after:duration-500 hover:after:opacity-20 group-hover:before:opacity-100"
               href="#0"
             >
-              <div className="relative z-20 h-full overflow-hidden rounded-[inherit] bg-gray-950 after:absolute after:inset-0 after:bg-linear-to-br after:from-gray-900/50 after:via-gray-800/25 after:to-gray-900/50">
+              <div className="relative z-20 h-full overflow-hidden rounded-[inherit] bg-white after:absolute after:inset-0 after:bg-white">
                 {/* Arrow */}
                 <div
-                  className="absolute right-6 top-6 flex h-8 w-8 items-center justify-center rounded-full border border-gray-700/50 bg-gray-800/65 text-gray-200 opacity-0 transition-opacity group-hover/card:opacity-100"
+                  className="absolute right-6 top-6 flex h-8 w-8 items-center justify-center rounded-full border border-gray-300 bg-gray-200 text-gray-600 opacity-0 transition-opacity group-hover/card:opacity-100"
                   aria-hidden="true"
                 >
                   <svg
@@ -155,13 +155,13 @@ export default function Workflows() {
                 {/* Content */}
                 <div className="p-6">
                   <div className="mb-3">
-                    <span className="btn-sm relative rounded-full bg-gray-800/40 px-2.5 py-0.5 text-xs font-normal before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:border before:border-transparent before:[background:linear-gradient(to_bottom,--theme(--color-gray-700/.15),--theme(--color-gray-700/.5))_border-box] before:[mask-composite:exclude_!important] before:[mask:linear-gradient(white_0_0)_padding-box,_linear-gradient(white_0_0)] hover:bg-gray-800/60">
+                    <span className="btn-sm relative rounded-full bg-gray-200/40 px-2.5 py-0.5 text-xs font-normal before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:border before:border-transparent before:[background:linear-gradient(to_bottom,#e5e7eb,#e5e7eb)] before:[mask-composite:exclude_!important] before:[mask:linear-gradient(white_0_0)_padding-box,_linear-gradient(white_0_0)] hover:bg-gray-200/60">
                       <span className="bg-linear-to-r from-indigo-500 to-indigo-200 bg-clip-text text-transparent">
                         Индивидуальные процессы
                       </span>
                     </span>
                   </div>
-                  <p className="text-indigo-200/65">
+                  <p className="text-gray-600">
                     Оптимизируйте разработку продукта с помощью платформы,
                     объединяющей спецификации и инсайты.
                   </p>


### PR DESCRIPTION
## Summary
- switch body text and background colors to light scheme
- update header, footer, hero and CTA styles
- adjust catalog and workflow cards for light theme
- tweak utility form styles

## Testing
- `npm install`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68812ee2a270833099d1aeb7d6ba6beb